### PR TITLE
show errors also in the error message of an exception

### DIFF
--- a/messagebird/client.py
+++ b/messagebird/client.py
@@ -18,9 +18,13 @@ ENDPOINT       = 'https://rest.messagebird.com'
 CLIENT_VERSION = '1.0.2'
 PYTHON_VERSION = '%d.%d.%d' % (sys.version_info[0], sys.version_info[1], sys.version_info[2])
 
-class ErrorException(BaseException):
+
+class ErrorException(Exception):
   def __init__(self, errors):
     self.errors = errors
+    message = ' '.join([str(e) for e in self.errors])
+    super(ErrorException, self).__init__(message)
+
 
 class Client(object):
   def __init__(self, access_key):

--- a/messagebird/error.py
+++ b/messagebird/error.py
@@ -5,3 +5,6 @@ class Error(Base):
     self.code        = None
     self.description = None
     self.parameter   = None
+
+  def __str__(self):
+    return str(dict(code=self.code, description=self.description, parameter=self.parameter))


### PR DESCRIPTION
for development it is nice to have the errors also in the exception error message like:
```
ErrorException: {'code': 20, 'parameter': None, 'description': u'message not found'}
```
instead of no message at all