### PR TITLE
Fix Python 3 compatibility issues

### DIFF
--- a/examples/message_create.py
+++ b/examples/message_create.py
@@ -31,7 +31,7 @@ try:
   print('  scheduledDatetime : %s' % msg.scheduledDatetime)
   print('  createdDatetime   : %s' % msg.createdDatetime)
   print('  recipients        : %s\n' % msg.recipients)
-  print
+  print()
 
 except messagebird.client.ErrorException as e:
   print('\nAn error occured while requesting a Message object:\n')

--- a/messagebird/base.py
+++ b/messagebird/base.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 class Base(object):
   def load(self, data):
-    for name, value in data.items():
+    for name, value in list(data.items()):
       if hasattr(self, name):
         setattr(self, name, value)
 

--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,9 @@ setup(
     keywords         = ['messagebird', 'sms'],
     install_requires = ['requests>=2.4.1'],
     license          = 'BSD-2-Clause',
+    classifiers      = [
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+    ],
 )


### PR DESCRIPTION
Fix Python 3 compatibility, the following issues were found using [2to3](https://docs.python.org/2/library/2to3.html):
- Usage of `dict.items()` in `messagebird/base.py`.
- A `print` statement in `examples/message_create.py`.

This PR also adds the classifiers to `setup.py` in order to add the '_Programming Language_' to the Messagebird PyPi project page.

