### PR TITLE
Update travis-ci matrix to use Python 3.4 istead of Python 3.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - 'pypy2.7'
   - 'pypy3.5'
   - '2.7'
-  - '3.3'
+  - '3.4'
   - '3.6'
   - 'nightly'
 install:


### PR DESCRIPTION
Travis updated their default distro to 16.04, which does not have
a 3.3 tarball