### PR TITLE
Drop python2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ target/
 
 # PyCharm
 .idea/
+*.iml
 
 # pyvenv
-venv/
+venv*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: python
 python:
-  - 'pypy2.7'
-  - 'pypy3.5'
-  - '2.7'
-  - '3.4'
+  - 'pypy3.6'
+  - 'pypy3.7'
   - '3.6'
+  - '3.7'
+  - '3.8'
+  - '3.9'
   - 'nightly'
 install:
-  - pip install mock==2.0
-  - pip install requests
-  - pip install codecov
-  - pip install pytest pytest-cov
-  - pip install pycodestyle
-  - pip install .
+  - pip install -e .[dev]
 script:
   - coverage run --source=messagebird -m unittest discover -s tests/
   - coverage report --fail-under=80
@@ -21,5 +17,3 @@ script:
 matrix:
   allow_failures:
   - python: 'nightly'
-  - python: 'pypy2.7'
-  - python: 'pypy3.5'

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import messagebird
 Then, create an instance of **messagebird.Client**:
 
 ```python
-client = messagebird.Client('test_gshuPaZoeEG6ovbc8M79w0QyM')
+client = messagebird.Client('YOUR_ACCESS_KEY')
 ```
 
 Now you can query the API for information or send a request. For example, if we want to request our balance information you'd do something like this:
@@ -83,7 +83,7 @@ Conversations WhatsApp Sandbox
 To use the whatsapp sandbox you need to add `messagebird.Feature.ENABLE_CONVERSATIONS_API_WHATSAPP_SANDBOX` to the list of features you want enabled. Don't forget to replace `YOUR_ACCESS_KEY` with your actual access key.
 
 ```python
-  client = messagebird.Client('1ekjMs368KTRlP0z6zfG9P70z', features=[messagebird.Feature.ENABLE_CONVERSATIONS_API_WHATSAPP_SANDBOX])
+client = messagebird.Client('YOUR_ACCESS_KEY', features=[messagebird.Feature.ENABLE_CONVERSATIONS_API_WHATSAPP_SANDBOX])
 ```
 
 Documentation

--- a/messagebird/base.py
+++ b/messagebird/base.py
@@ -4,7 +4,7 @@ import dateutil.parser
 import json
 
 
-class Base(object):
+class Base:
     def load(self, data):
         for name, value in list(data.items()):
             if hasattr(self, name) and not callable(getattr(self, name)):

--- a/messagebird/client.py
+++ b/messagebird/client.py
@@ -26,7 +26,7 @@ from messagebird.call_flow import CallFlow, CallFlowList, CallFlowNumberList
 from messagebird.number import Number, NumberList
 
 ENDPOINT = 'https://rest.messagebird.com'
-CLIENT_VERSION = '1.4.1'
+CLIENT_VERSION = '2.0.0'
 PYTHON_VERSION = '%d.%d.%d' % (sys.version_info[0], sys.version_info[1], sys.version_info[2])
 USER_AGENT = 'MessageBird/ApiClient/%s Python/%s' % (CLIENT_VERSION, PYTHON_VERSION)
 REST_TYPE = 'rest'

--- a/messagebird/client.py
+++ b/messagebird/client.py
@@ -69,7 +69,7 @@ class Feature(enum.Enum):
     ENABLE_CONVERSATIONS_API_WHATSAPP_SANDBOX = 1
 
 
-class Client(object):
+class Client:
 
     def __init__(self, access_key, http_client=None, features=[]):
         self.access_key = access_key

--- a/messagebird/http_client.py
+++ b/messagebird/http_client.py
@@ -11,7 +11,7 @@ class ResponseFormat(Enum):
     binary = 2
 
 
-class HttpClient(object):
+class HttpClient:
     """Used for sending simple HTTP requests."""
 
     def __init__(self, endpoint, access_key, user_agent):

--- a/messagebird/http_client.py
+++ b/messagebird/http_client.py
@@ -3,10 +3,7 @@ from enum import Enum
 
 from messagebird.serde import json_serialize
 
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin
+from urllib.parse import urljoin
 
 
 class ResponseFormat(Enum):

--- a/messagebird/signed_request.py
+++ b/messagebird/signed_request.py
@@ -4,10 +4,7 @@ import base64
 import time
 from collections import OrderedDict
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
+from urllib.parse import urlencode
 
 
 class SignedRequest:

--- a/setup.py
+++ b/setup.py
@@ -2,31 +2,38 @@ from os import path
 from setuptools import setup
 from io import open
 
-def get_description():
-    working_directory = path.abspath(path.dirname(__file__))
-    readme_path = path.join(working_directory, 'README.md')
-    with open(readme_path, encoding='utf-8') as f:
-        return (f.read(), 'text/markdown')
-
-description, description_content_type = get_description()
+with open('README.md', encoding='utf-8') as f:
+    description = f.read()
 
 setup(
     name                          = 'messagebird',
     packages                      = ['messagebird'],
-    version                       = '1.5.0',
+    version                       = '2.0.0',
     description                   = "MessageBird's REST API",
     author                        = 'MessageBird',
     author_email                  = 'support@messagebird.com',
     long_description              = description,
-    long_description_content_type = description_content_type,
+    long_description_content_type = 'text/markdown',
     url                           = 'https://github.com/messagebird/python-rest-api',
-    download_url                  = 'https://github.com/messagebird/python-rest-api/tarball/1.4.1',
+    download_url                  = 'https://github.com/messagebird/python-rest-api/tarball/2.0.0',
     keywords                      = ['messagebird', 'sms'],
     install_requires              = ['requests>=2.4.1', 'python-dateutil>=2.6.0'],
+    extras_require               = {
+        'dev': [
+            'pytest',
+            'pytest-cov',
+            'mock>=2.0',
+            'codecov',
+            'pycodestyle',
+        ]
+    },
     license                       = 'BSD-2-Clause',
     classifiers                   = [
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Operating System :: OS Independent',
     ],
 )

--- a/tests/test_balance.py
+++ b/tests/test_balance.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client
 
 
 class TestBalance(unittest.TestCase):

--- a/tests/test_call.py
+++ b/tests/test_call.py
@@ -1,15 +1,9 @@
 import json
 import unittest
-from messagebird import Client, ErrorException
-from messagebird.base import Base
-from messagebird.client import VOICE_TYPE
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client
+from messagebird.base import Base
 
 
 class TestCall(unittest.TestCase):

--- a/tests/test_call_flow.py
+++ b/tests/test_call_flow.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client
 
 
 class TestCallFlow(unittest.TestCase):

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client, ErrorException
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client, ErrorException
 
 
 class TestContact(unittest.TestCase):

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,16 +1,10 @@
 import unittest
 from datetime import datetime
+from unittest.mock import Mock
 
 from dateutil.tz import tzutc
 
 from messagebird import Client
-
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
 
 
 class TestConversation(unittest.TestCase):

--- a/tests/test_conversation_message.py
+++ b/tests/test_conversation_message.py
@@ -1,16 +1,10 @@
 import unittest
 from datetime import datetime
+from unittest.mock import Mock
 
 from dateutil.tz import tzutc
 
 from messagebird import Client
-
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
 
 
 class TestConversationMessage(unittest.TestCase):

--- a/tests/test_conversation_webhook.py
+++ b/tests/test_conversation_webhook.py
@@ -1,6 +1,7 @@
-import unittest
 import json
+import unittest
 from datetime import datetime
+from unittest.mock import Mock
 
 from dateutil.tz import tzutc
 
@@ -8,13 +9,6 @@ from messagebird import Client
 from messagebird.conversation_webhook import \
     CONVERSATION_WEBHOOK_EVENT_CONVERSATION_CREATED, \
     CONVERSATION_WEBHOOK_EVENT_CONVERSATION_UPDATED
-
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
 
 
 class TestConversationWebhook(unittest.TestCase):

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client
 
 
 class TestGroup(unittest.TestCase):

--- a/tests/test_hlr.py
+++ b/tests/test_hlr.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client
 
 
 class TestHLR(unittest.TestCase):

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client
 
 
 class TestLookup(unittest.TestCase):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client, ErrorException
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client, ErrorException
 
 
 class TestMessage(unittest.TestCase):

--- a/tests/test_mms.py
+++ b/tests/test_mms.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client
 
 
 class TestMMS(unittest.TestCase):

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client, ErrorException
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client, ErrorException
 
 
 class TestNumber(unittest.TestCase):

--- a/tests/test_signed_request.py
+++ b/tests/test_signed_request.py
@@ -1,13 +1,7 @@
-import unittest
 import time
-from messagebird.signed_request import SignedRequest
+import unittest
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird.signed_request import SignedRequest
 
 SIGNING_KEY = 'PlLrKaqvZNRR5zAjm42ZT6q1SQxgbbGd'
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client, ErrorException
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client, ErrorException
 
 
 class TestVerify(unittest.TestCase):

--- a/tests/test_voice_recording.py
+++ b/tests/test_voice_recording.py
@@ -1,16 +1,10 @@
 import unittest
+from datetime import datetime
+from unittest.mock import Mock
 
 from dateutil.tz import tzutc
 
 from messagebird import Client, ErrorException
-from datetime import datetime
-
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
 
 
 class TestVoiceRecording(unittest.TestCase):

--- a/tests/test_voice_transcription.py
+++ b/tests/test_voice_transcription.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client
 
 
 class TestVoiceTranscription(unittest.TestCase):

--- a/tests/test_voice_webhook.py
+++ b/tests/test_voice_webhook.py
@@ -1,18 +1,11 @@
-import json
 import unittest
+from unittest.mock import Mock
 
 from messagebird import Client
 from messagebird.client import VOICE_WEB_HOOKS_PATH, VOICE_API_ROOT
 from messagebird.error import ValidationError
 from messagebird.serde import json_serialize
 from messagebird.voice_webhook import VoiceCreateWebhookRequest, VoiceUpdateWebhookRequest
-
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
 
 
 class TestVoiceWebhook(unittest.TestCase):

--- a/tests/test_voicemessage.py
+++ b/tests/test_voicemessage.py
@@ -1,12 +1,7 @@
 import unittest
-from messagebird import Client
+from unittest.mock import Mock
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    # mock was added to unittest in Python 3.3, but was an external library
-    # before.
-    from mock import Mock
+from messagebird import Client
 
 
 class TestVoicemessage(unittest.TestCase):


### PR DESCRIPTION
# Description

Sun has set on python2 and we need to carry on,

Additionally:
* Bumps version to `2.0.0`
* Sets IntelliJ module files and venv* as ignored.
* Removes references to ACCESS_KEY in `README.md`. Replaces with `YOUR_ACCESS_KEY`.
* Moves requirements to `setup.py`.
* Removes python2 from `setup.py`.
* Removes python3.5 from `setup.py`.
* Adds new major versions of python3.
* Removes python2 imports.
* Bumps `UserAgent` string to 2.0.0.
* Removes extend from `object`.
* Removes Python2 imports from the tests.

# Testing
* Unit tests pass.
* Kept as WIP as I only have limited set (send SMS) of E2E or integration tests to use against the new version. 
