### PR TITLE
Fix wrong add-contacts-into-group usage

### DIFF
--- a/messagebird/client.py
+++ b/messagebird/client.py
@@ -347,14 +347,7 @@ class Client(object):
         self.request_plain_text('groups/' + str(id), 'PATCH', params)
 
     def group_add_contacts(self, groupId, contactIds):
-        query = self.__group_add_contacts_query(contactIds)
-        self.request_plain_text('groups/' + str(groupId) + '?' + query, 'PUT', None)
-
-    def __group_add_contacts_query(self, contactIds):
-        # __group_add_contacts_query gets a query string to add contacts to a
-        # group. The expected format is ids[]=first-contact&ids[]=second-contact.
-        # See: https://developers.messagebird.com/docs/groups#add-contact-to-group.
-        return '&'.join('ids[]=' + str(id) for id in contactIds)
+        self.request_plain_text(f'groups/{groupId}/contacts/', 'PUT', {'ids': contactIds})
 
     def group_remove_contact(self, groupId, contactId):
         self.request_plain_text('groups/' + str(groupId) + '/contacts/' + str(contactId), 'DELETE', None)

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -59,8 +59,8 @@ class TestGroup(unittest.TestCase):
 
         Client('', http_client).group_add_contacts('group-id', ['contact-id', 'other-contact-id'])
 
-        http_client.request.assert_called_once_with('groups/group-id?ids[]=contact-id&ids[]=other-contact-id', 'PUT',
-                                                    None)
+        http_client.request.assert_called_once_with('groups/group-id/contacts/', 'PUT',
+                                                    {'ids': ['contact-id', 'other-contact-id']})
 
     def test_group_remove_contact(self):
         http_client = Mock()


### PR DESCRIPTION
Accordingly to documentation https://developers.messagebird.com/api/groups/#add-contact-to-group change adding clients into group