### PR TITLE
Deprecate CallFlow Title usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ MessageBird's REST API for Python
 =================================
 This repository contains the open source Python client for MessageBird's REST API. Documentation can be found at: https://developers.messagebird.com/.
 
+Something random
+
 Requirements
 ------------
 - [Sign up](https://www.messagebird.com/en/signup) for a free MessageBird account

--- a/examples/call_create.py
+++ b/examples/call_create.py
@@ -8,7 +8,7 @@ import requests
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import messagebird
 
-exampleCallFlow = '{"title":"Test Flow","steps":[{"action":"say","options":{"payload":"Hey, this is your first voice \
+exampleCallFlow = '{"steps":[{"action":"say","options":{"payload":"Hey, this is your first voice \
 call","language":"en-GB","voice":"female"}}]}'
 
 parser = argparse.ArgumentParser(usage='call_create.py\

--- a/examples/call_flow.py
+++ b/examples/call_flow.py
@@ -28,7 +28,6 @@ try:
     # Print the object information.
     print('\nThe following information was returned as a CallFlow object:\n')
     print('  id           : {}'.format(call.id))
-    print('  title        : {}'.format(call.title))
     print('  steps        : ')
     for step in call.steps:
         print(step)

--- a/messagebird/client.py
+++ b/messagebird/client.py
@@ -504,12 +504,16 @@ class Client(object):
         query = self._format_query(limit, offset)
         return CallFlowList().load(self.request('call-flows?' + query, 'GET', None, VOICE_TYPE))
 
-    def call_flow_create(self, title, steps, default=False, record=False):
-        params = {'title': title, 'steps': steps, 'default': default, 'record': record}
+    def call_flow_create(self, steps, default=False, record=False, title=None):
+        params = {'steps': steps, 'default': default, 'record': record}
+        if title is not None:
+            params['title'] = title
         return CallFlow().load(self.request('call-flows', 'POST', params, VOICE_TYPE))
 
-    def call_flow_update(self, id, title, steps, default, record):
-        params = {'title': title, 'steps': steps, 'default': default, 'record': record}
+    def call_flow_update(self, id, steps, default, record, title=None):
+        params = {'steps': steps, 'default': default, 'record': record}
+        if title is not None:
+            params['title'] = title
         return CallFlow().load(self.request('call-flows/' + str(id), 'PUT', params, VOICE_TYPE))
 
     def call_flow_delete(self, id):

--- a/tests/test_call.py
+++ b/tests/test_call.py
@@ -126,7 +126,6 @@ class TestCall(unittest.TestCase):
             "source": "31644556677",
             "destination": "31612345678",
             "callFlow": {
-                "title": "Say message",
                 "steps": [
                     {
                         "action": "say",

--- a/tests/test_call_flow.py
+++ b/tests/test_call_flow.py
@@ -45,7 +45,6 @@ class TestCallFlow(unittest.TestCase):
           "data": [
             {
               "id": "de3ed163-d5fc-45f4-b8c4-7eea7458c635",
-              "title": "Forward call to 31612345678",
               "record": false,
               "steps": [
                 {
@@ -64,7 +63,6 @@ class TestCallFlow(unittest.TestCase):
             },
             {
               "id": "de3ed163-d5fc-45f4-b8c4-7eea7458c634",
-              "title": "Forward call to 0600123123",
               "record": true,
               "steps": [
                 {
@@ -97,8 +95,9 @@ class TestCallFlow(unittest.TestCase):
         call_flow_list = Client('', http_client).call_flow_list(20, 0)
 
         http_client.request.assert_called_once_with('call-flows?limit=20&offset=0', 'GET', None)
+        self.assertEqual(call_flow_list.data[0].title, None)
+        self.assertEqual(call_flow_list.data[1].title, None)
 
-        self.assertEqual('Forward call to 0600123123', call_flow_list.data[1].title)
         self.assertEqual(2, call_flow_list.pagination['totalCount'])
 
     def test_numbers_list(self):


### PR DESCRIPTION
This field is deprecated now although users still can send and receive it.