### PR TITLE
Add Token property to Verify Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.2.0
+
+* [Added] Token parameter to Verify Object
 ## 2.1.0
 
 * [ADDED] Support for JWT webhook signature.

--- a/messagebird/verify.py
+++ b/messagebird/verify.py
@@ -7,6 +7,7 @@ class Verify(Base):
         self.href = None
         self.recipient = None
         self.reference = None
+        self.token = None
         self.messages = None
         self.status = None
         self._createdDatetime = None

--- a/messagebird/version.py
+++ b/messagebird/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.1.0'
+VERSION = '2.2.0'


### PR DESCRIPTION
## Description

Token is returned when creating a Verify object, when `returnToken=true` is given as create parameter.

## CHANGELOG

* [Added] Token parameter to Verify Object
